### PR TITLE
Utilize meili for filtering & improved overall filter performance

### DIFF
--- a/search/__init__.py
+++ b/search/__init__.py
@@ -23,8 +23,10 @@ def parse_documents():
 
         # add parsed_sample_size = first number in sample_size
         sample_size = entry_json.get("sample_size")
-        if sample_size:
-            sample_sizes = re.findall(r"^\D*(\d+)")
+        if type(sample_size) == int:
+            entry_json["parsed_sample_size"] = sample_size
+        elif sample_size:
+            sample_sizes = re.findall(r"^\D*(\d+)", str(sample_size))
             if len(sample_sizes):
                 entry_json["parsed_sample_size"] = int(sample_sizes[0])
         else:

--- a/search/__init__.py
+++ b/search/__init__.py
@@ -1,7 +1,10 @@
 import sys
-sys.path.append('../')
-from utils import db, ms
 import json
+import re
+
+sys.path.append("../")
+from utils import db, ms
+
 
 def parse_documents():
     parsed_documents = []
@@ -18,9 +21,19 @@ def parse_documents():
         del entry_json["_id"]
         entry_json["ms-id"] = oid
 
+        # add parsed_sample_size = first number in sample_size
+        sample_size = entry_json.get("sample_size")
+        if sample_size:
+            sample_sizes = re.findall(r"^\D*(\d+)")
+            if len(sample_sizes):
+                entry_json["parsed_sample_size"] = int(sample_sizes[0])
+        else:
+            entry_json["parsed_sample_size"] = -1
+
         parsed_documents.append(entry_json)
     print(f"Retrieved {len(parsed_documents)} documents from MongoDB")
     return parsed_documents
+
 
 def push_to_meili(documents):
     client = ms.get_ms_client()
@@ -39,13 +52,15 @@ def push_to_meili(documents):
     # don't return until all documents have been pushed
     status = None
     while status != "processed":
-       update_status = index.get_update_status(update_id)
-       status = update_status.get("status")
+        update_status = index.get_update_status(update_id)
+        status = update_status.get("status")
     print("Successfully uploaded data to Meilisearch")
+
 
 def mongo_to_meili():
     docs = parse_documents()
     push_to_meili(docs)
+
 
 def perform_meili_search(query):
     client = ms.get_ms_client()

--- a/serve.py
+++ b/serve.py
@@ -153,15 +153,14 @@ def filter_papers(
         filter_sample_size(results, int(min_subjects), int(max_subjects))
     else:
         prebuilt_filters = [
-            f"{key} = '{value}'" for key, value in dynamic_filters.items() if value
+            f"{key} _= '{value}'" for key, value in dynamic_filters.items() if value
         ]
-        # parsed_sample_size = -1 if couldn't parse sample_size, so if filtering
-        # on sample_size at all, make sure to exclude the invalid by adding >= 0
-        # TODO: UNCOMMENT THIS
-        # if min_subjects or max_subjects:
-        #     prebuilt_filters.push(f"parsed_sample_size >= {min_subjects}")
-        # if max_subjects:
-        #     prebuilt_filters.push(f"parsed_sample_size <= {max_subjects}")
+        # parsed_sample_size is -1 if couldn't parse sample_size, so if filtering
+        # on sample_size at all, make sure to exclude the invalid entries by adding >= 0
+        if min_subjects or max_subjects:
+            prebuilt_filters.push(f"parsed_sample_size >= {min_subjects}")
+        if max_subjects:
+            prebuilt_filters.push(f"parsed_sample_size <= {max_subjects}")
 
         prebuilt_filters = "AND".join(prebuilt_filters)
 
@@ -277,11 +276,7 @@ def filter():
             max_subjects = 0
 
         papers, page = filter_papers(
-            page,
-            filters.get("q", ""),
-            dynamic_filters,
-            min_subjects,
-            max_subjects,
+            page, filters.get("q", ""), dynamic_filters, min_subjects, max_subjects,
         )
 
         if len(papers) and is_article(papers[0]):

--- a/serve.py
+++ b/serve.py
@@ -154,7 +154,7 @@ def filter_papers(
     else:
         escape = lambda x: x.replace('"', '\\"')
         prebuilt_filters = [
-            f'{key} _= "{escape(value)}"'
+            f'{key} *= "{escape(value)}"'
             for key, value in dynamic_filters.items()
             if value
         ]

--- a/serve.py
+++ b/serve.py
@@ -152,8 +152,11 @@ def filter_papers(
 
         filter_sample_size(results, int(min_subjects), int(max_subjects))
     else:
+        escape = lambda x: x.replace('"', '\\"')
         prebuilt_filters = [
-            f"{key} _= '{value}'" for key, value in dynamic_filters.items() if value
+            f'{key} _= "{escape(value)}"'
+            for key, value in dynamic_filters.items()
+            if value
         ]
         # parsed_sample_size is -1 if couldn't parse sample_size, so if filtering
         # on sample_size at all, make sure to exclude the invalid entries by adding >= 0

--- a/serve.py
+++ b/serve.py
@@ -186,6 +186,11 @@ def filter_papers(
         # perform meilisearch query
         results = ms_index.search(qraw, options).get("hits")
 
+        # sort by timestamp descending
+        results = sorted(
+            results, key=lambda r: r.get("timestamp", {}).get("$date", -1), reverse=True
+        )
+
     if len(results) < PAGE_SIZE:
         page = -1
 
@@ -222,7 +227,7 @@ def intmain():
     if request.headers.get("Content-Type", "") == "application/json":
         page = get_page()
 
-        papers = db.Article.objects.skip((page - 1) * PAGE_SIZE).limit(page * PAGE_SIZE)
+        papers = db.Article.objects.skip((page - 1) * PAGE_SIZE).limit(PAGE_SIZE)
         return jsonify(
             dict(page=page, papers=list(map(lambda p: json.loads(p.to_json()), papers)))
         )


### PR DESCRIPTION
**DO NOT MERGE UNTIL RUNNING MEILISEARCH WITH NEW CONTAINS FILTER FUNCTION**

Automatically parse `sample_size` when sending data from Mongo to MeiliSearch so that we can perform filter comparisons quickly and optimize filters.
Improved overall filter performance.
Implemented all filters with meili when a term is being searched for maximum performance.
Fixed paging/filtering complications.

Fixes #50 