### PR TITLE
Preload filter options and display as dropdowns under advanced filters

### DIFF
--- a/fetch/__init__.py
+++ b/fetch/__init__.py
@@ -36,6 +36,7 @@ def run():
 
     db.create(db.Article, articles_with_location)
 
+    preload_filter_options()
     mongo_to_meili()
 
 
@@ -46,5 +47,34 @@ def translate(info):
         return faucet.translate(info)
     return info
 
-def preload_filters():
-    articles = db.Article.objects()
+
+FILTER_OPTION_KEYS = [
+    "sponsor",
+    # "location",
+    "recruiting_status",
+]
+
+
+def preload_filter_options():
+    """
+    Aggregate all Articles' existing values for given FILTER_OPTION_KEYS and save them to the FilterOption collection in Mongo, replacing those that already exist.
+    """
+
+    filter_options = {key: set() for key in FILTER_OPTION_KEYS}
+    # keep track of set of casefolded values to preserve case of the common values
+    existing_filter_options = {key: set() for key in FILTER_OPTION_KEYS}
+
+    for article in db.Article.objects().only(*FILTER_OPTION_KEYS):
+        for key, s in filter_options.items():
+            value = str(eval(f"article.{key}") or "")
+            if value and value.casefold() not in existing_filter_options[key]:
+                s.add(value)
+                existing_filter_options[key].add(value.casefold())
+
+    filter_option_data = []
+    for key, values in filter_options.items():
+        for value in values:
+            filter_option_data.append({"key": key, "value": value})
+    # clear collection before adding new values
+    db.FilterOption.objects.delete()
+    db.create(db.FilterOption, filter_option_data)

--- a/fetch/__init__.py
+++ b/fetch/__init__.py
@@ -45,3 +45,6 @@ def translate(info):
     if faucet:
         return faucet.translate(info)
     return info
+
+def preload_filters():
+    articles = db.Article.objects()

--- a/serve.py
+++ b/serve.py
@@ -410,7 +410,8 @@ def search():
         # add filter options for those that exist
         filter_options = db.FilterOption.objects()
         ctx["filter_options"] = {
-            k: list(v) for k, v in groupby(filter_options, key=lambda o: o.key)
+            k: list(map(lambda o: o.value, v))
+            for k, v in groupby(filter_options, key=lambda o: o.key)
         }
 
         return render_template("search.html", **ctx)

--- a/serve.py
+++ b/serve.py
@@ -240,7 +240,7 @@ def filter_papers(page, qraw, dynamic_filters=[]):
 
 
 def default_context(**kws):
-    ans = dict(filter_options={}, filters={}, total_count=db.Article.objects.count(),)
+    ans = dict(filter_options={}, filters={}, total_count=db.Article.objects.count())
     ans.update(kws)
 
     # add cmd filters to advanced filters inputs

--- a/static/style.css
+++ b/static/style.css
@@ -418,16 +418,18 @@ form.horizontal > header > span {
 	margin-top: 0.3rem;
 }
 
-input, textarea {
+input, textarea, select {
 	font-family: 'SF Pro', Arial, sans-serif;
 	font-size: 14px;
 	border: 1px solid #ddd;
 	border-radius: 12px;
 	padding: 5px 7px;
+	width: 100%;
 }
 
-input:focus, textarea:focus {
+input:focus, textarea:focus, select:focus {
 	outline: none;
+	border: 1px solid #555;
 }
 
 button, input[type=submit] {

--- a/templates/search.html
+++ b/templates/search.html
@@ -64,28 +64,6 @@
       </a>
       <br>
       <div id="filters-container" style="display: {{ 'grid' if adv_filters_in_use else 'none' }};">
-        {% if false %}
-        <!-- if false ensures this doesn't get send to device, don't show for now -->
-        <label for="country">Country:</label>
-        <select name="country" type="text" id="filter-country">
-          {% if filters and not 'country' in filters %}
-          <option value="" selected></option>
-          {% else %}
-          <option value=""></option>
-          {% endif %}
-
-          {% if filter_options and 'countries' in filter_options %}
-          {% for country in filter_options.countries %}
-          {% if filters and 'country' in filters and filters.country == country %}
-          <option value="{{ country }}" selected>{{ country }}</option>
-          {% else %}
-          <option value="{{ country }}">{{ country }}</option>
-          {% endif %}
-          {% endfor %}
-          {% endif %}
-        </select>
-        {% endif %}
-
         <label for="date">Date Posted:</label>
         <div class="inputs">
           <input name="min-timestamp" type="text" id="filter-min-timestamp" value="{{ filters.get("min-timestamp", "") }}"
@@ -95,8 +73,25 @@
         </div>
 
         <label for="sponsor">Sponsor:</label>
-        <input name="sponsor" type="text" id="filter-sponsor"
-          value="{{ filters.sponsor if filters and 'sponsor' in filters else '' }}" autocomplete="off" autocapitalize="off" spellcheck="false">
+        <select name="sponsor" type="text" id="filter-sponsor">
+          <!-- Add blank option -->
+          {% if filters and not 'sponsor' in filters %}
+          <option value="" selected></option>
+          {% else %}
+          <option value=""></option>
+          {% endif %}
+
+          <!-- Loop over options -->
+          {% if filter_options and 'sponsor' in filter_options %}
+          {% for sponsor in filter_options.sponsor %}
+          {% if filters and 'sponsor' in filters and filters.sponsor == sponsor %}
+          <option value="{{ sponsor }}" selected>{{ sponsor }}</option>
+          {% else %}
+          <option value="{{ sponsor }}">{{ sponsor }}</option>
+          {% endif %}
+          {% endfor %}
+          {% endif %}
+        </select>
 
         <label for="target_disease">Condition:</label>
         <input name="target_disease" type="text" id="filter-target_disease"
@@ -105,29 +100,6 @@
         <label for="intervention">Intervention:</label>
         <input name="intervention" type="text" id="filter-intervention"
           value="{{ filters.intervention if filters and 'intervention' in filters else '' }}" autocomplete="off" autocapitalize="off" spellcheck="false">
-
-        <!--
-          <div class="filter">
-            <label for="type">Trial Type:</label>
-            <select name="type" type="text" id="filter-type">
-              {% if filters and not 'type' in filters %}
-              <option value="" selected></option>
-              {% else %}
-              <option value=""></option>
-              {% endif %}
-
-              {% if filter_options and 'types' in filter_options %}
-              {% for type in filter_options.types %}
-              {% if filters and 'type' in filters and filters.type == type %}
-              <option value="{{ type }}" selected>{{ type }}</option>
-              {% else %}
-              <option value="{{ type }}">{{ type }}</option>
-              {% endif %}
-              {% endfor %}
-              {% endif %}
-            </select>
-          </div>
-          -->
 
         <label for="sample_size">Sample Size:</label>
         <div class="inputs">
@@ -142,8 +114,25 @@
           value="{{ filters.location if filters and 'location' in filters else '' }}" autocomplete="off" autocapitalize="off" spellcheck="false">
 
         <label for="recruiting_status">Status:</label>
-        <input name="recruiting_status" type="text" id="filter-recruiting_status"
-          value="{{ filters.recruiting_status if filters and 'recruiting_status' in filters else '' }}" autocomplete="off" autocapitalize="off" spellcheck="false">
+        <select name="recruiting_status" type="text" id="filter-recruiting_status">
+          <!-- Add blank option -->
+          {% if filters and not 'recruiting_status' in filters %}
+          <option value="" selected></option>
+          {% else %}
+          <option value=""></option>
+          {% endif %}
+
+          <!-- Loop over options -->
+          {% if filter_options and 'recruiting_status' in filter_options %}
+          {% for recruiting_status in filter_options.recruiting_status %}
+          {% if filters and 'recruiting_status' in filters and filters.recruiting_status == recruiting_status %}
+          <option value="{{ recruiting_status }}" selected>{{ recruiting_status }}</option>
+          {% else %}
+          <option value="{{ recruiting_status }}">{{ recruiting_status }}</option>
+          {% endif %}
+          {% endfor %}
+          {% endif %}
+        </select>
 
         <input type="submit" value="Search">
       </div>

--- a/utils/db.py
+++ b/utils/db.py
@@ -86,7 +86,7 @@ class FilterOption(ExtendedDocument):
     }
 
 
-def create(articles):
+def create(Model, objects):
     """
     Input: list of objects (dictionaries).
     Output: None

--- a/utils/db.py
+++ b/utils/db.py
@@ -78,6 +78,12 @@ class Article(ExtendedDocument):
 
 class FilterOption(ExtendedDocument):
     key = StringField()
+    value = StringField()
+
+    meta = {
+        "indexes": [{"fields": ["key", "value"], "unique": True}],
+        "ordering": ["key", "value"],
+    }
 
 
 def create(articles):

--- a/utils/db.py
+++ b/utils/db.py
@@ -76,7 +76,11 @@ class Article(ExtendedDocument):
         return self.url
 
 
-def create(Model, objects):
+class FilterOption(ExtendedDocument):
+    key = StringField()
+
+
+def create(articles):
     """
     Input: list of objects (dictionaries).
     Output: None


### PR DESCRIPTION
Fixes #91

Currently only does it for `sponsor` and `recruiting_status` but is easily extensible by adding the key to `FILTER_OPTION_KEYS` in `fetch/__init__.py` and replacing the `input` in `search.html` with a `select` element.