### PR TITLE
Clickable date filters

### DIFF
--- a/serve.py
+++ b/serve.py
@@ -51,8 +51,8 @@ slack_api_url = os.environ.get("SLACK_WEBHOOK_URL", "")
 
 PAGE_SIZE = 25
 
-# `"April 1, 2020"` or `April1,2020`
-quoted_or_single_word = "\\s*(?:(?:(?:\"|')(.*)(?:\"|'))|(?:([^\\s]*)))"
+# `"April 1, 2020"` or `'April 1, 2020'` or `April1,2020`
+quoted_or_single_word = "\\s*(?:(?:\"([^\"]*)\")|(?:'([^']*)')|(?:([^\\s]*)))"
 # { regex: filter_key }
 CMDS = {
     f"mindate:{quoted_or_single_word}": "min-timestamp",

--- a/static/search.css
+++ b/static/search.css
@@ -210,3 +210,15 @@ form.horizontal > header > span {
   margin-bottom: 2rem;
   font-size: 14px;
 }
+
+.shortcut-filter {
+  display: inline-block;
+  cursor: pointer;
+  line-height: 20px;
+  transition: transform 0.2s ease;
+}
+
+.shortcut-filter:hover,
+.shortcut-filter:active {
+  transform: scale(1.05);
+}

--- a/static/search.js
+++ b/static/search.js
@@ -14,7 +14,7 @@ $.ajaxSetup({
 // toastr.options.positionClass = 'toast-bottom-right';
 
 // if not on search, dont add
-var page = window.location.pathname === "/" ? -1 : 0;
+var page = 0;
 var loadingTimeout = null;
 
 function addPapers() {
@@ -135,19 +135,38 @@ function addPapers() {
 
 // when page loads...
 $(document).ready(function () {
-  // add papers to #rtable
-  addPapers();
+  // splash search page, no results
+  if (window.location.pathname === "/") {
+    var q = $("#qfield");
+    $(".shortcut-filter").click(function () {
+      var text = $(this).data("text");
+      var idxFromEnd = text.length - text.indexOf("|");
+      text = text.replace("|", "");
 
-  // set up infinite scrolling for adding more papers
-  $(window).on("scroll", function () {
-    var scrollTop = $(document).scrollTop();
-    var windowHeight = $(window).height();
-    var bodyHeight = $(document).height() - windowHeight;
-    var scrollPercentage = scrollTop / bodyHeight;
-    if (scrollPercentage > 0.9) {
-      addPapers();
-    }
-  });
+      var newVal = (q.val().trim() + " " + text).trim();
+      q.val(newVal);
+      q.focus();
+
+      var idx = newVal.length - idxFromEnd + 1;
+      q[0].setSelectionRange(idx, idx);
+    });
+
+    // search page after results returned
+  } else {
+    // add papers to #rtable
+    addPapers();
+
+    // set up infinite scrolling for adding more papers
+    $(window).on("scroll", function () {
+      var scrollTop = $(document).scrollTop();
+      var windowHeight = $(window).height();
+      var bodyHeight = $(document).height() - windowHeight;
+      var scrollPercentage = scrollTop / bodyHeight;
+      if (scrollPercentage > 0.9) {
+        addPapers();
+      }
+    });
+  }
 });
 
 function toggleAdvancedFilters() {
@@ -165,11 +184,11 @@ function toggleAdvancedFilters() {
 
 // TODO(gmittal): Move this to server-side
 function getRegistry(url) {
-  let host = url.split('/')[2];
+  let host = url.split("/")[2];
   let registries = {
-    'clinicaltrials.gov': 'clinicaltrials.gov',
-    'www.clinicaltrialsregister.eu': 'EU Clinical Trials Register',
-    'isrctn.com': 'ISRCTN',
-  }
+    "clinicaltrials.gov": "clinicaltrials.gov",
+    "www.clinicaltrialsregister.eu": "EU Clinical Trials Register",
+    "isrctn.com": "ISRCTN",
+  };
   return registries[host];
 }

--- a/templates/search.html
+++ b/templates/search.html
@@ -45,7 +45,7 @@
           autocomplete="off" autocapitalize="off" spellcheck="false">
       </div>
 
-      <span id="hint">Hint: try adding <em>mindate:"April 1, 2020"</em> or <em>maxdate:2020-03-15</em> to your search</span>
+      <span id="hint">Hint: try adding <em class="shortcut-filter" data-text="mindate:&quot;|&quot;">mindate:"April 1, 2020"</em> or <em class="shortcut-filter" data-text="maxdate:&quot;|&quot;">maxdate:2020-03-15</em> to your search</span>
     </header>
 
     <div id="filters-box" {{ 'style=display:none' if url_for(request.endpoint) == '/' else '' }}>


### PR DESCRIPTION
Resolves #109 

Added ability to click on date filter examples in the hint under the search bar.
Also discovered and fixed a bug where `mindate:"X" maxdate:"Y"` would be interpreted as just the minimum date filter with a value of `X" maxdate:"Y`. The regex was not requiring the capturing group to not include the opening/closing quote character.